### PR TITLE
Update the HELICS GitHub repo url in CPack information

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "extern/HELICS"]
 	path = extern/HELICS
-	url = https://github.com/GMLC-TDC/HELICS-src.git
+	url = https://github.com/GMLC-TDC/HELICS.git
 	branch = develop
 [submodule "extern/gtest"]
 	path = extern/gtest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -368,7 +368,7 @@ if(ENABLE_PACKAGE_BUILD)
         set(CPACK_NSIS_INSTALL_ROOT "C:\\\\local")
         set(
             CPACK_NSIS_URL_INFO_ABOUT
-            "https://www.github.com/GMLC-TDC/Helics-src"
+            "https://www.github.com/GMLC-TDC/HELICS"
         )
         set(CPACK_NSIS_HELP_LINK "https://helics.readthedocs.io/en/latest")
         set(CPACK_NSIS_CONTACT "helicsteam@helics.org")
@@ -378,7 +378,7 @@ if(ENABLE_PACKAGE_BUILD)
         set(CPACK_NSIS_EXECUTABLES_DIRECTORY ${CMAKE_INSTALL_BINDIR})
         set(
             CPACK_NSIS_MENU_LINKS
-            "https://www.github.com/GMLC-TDC/Helics-src"
+            "https://www.github.com/GMLC-TDC/HELICS"
             "HELICS Github"
             "https://helics.readthedocs.io/en/latest"
             "Helics Documentation"


### PR DESCRIPTION
Updating url for HELICS-src to HELICS repo rename on June 19, 2019.